### PR TITLE
Tweak ZAP references

### DIFF
--- a/s3.md
+++ b/s3.md
@@ -43,8 +43,8 @@ amazonaws
 A brute-force approach, possibly based on a word-list of common words along with specific words coming from the domain under testing, might be useful in identifying S3 buckets. 
 As described in the previous section, S3 buckets are identified by a predefined and predictable schema that can be useful for buckets identification. By means of an automatic tool it is possible to test multiple URLs in search of S3 buckets starting from a word-list.
 
-In OWASP ZAP (v2.7.0) the fuzzer feature can be used for testing:
-# With OWASP ZAP up and running, navigate to <code>https://s3.amazonaws.com/bucket</code> to generate a request to <code>https://s3.amazonaws.com/bucket</code> in the <code>Sites</code> panel;
+In ZAP the fuzzer feature can be used for testing:
+# With ZAP up and running, navigate to <code>https://s3.amazonaws.com/bucket</code> to generate a request to <code>https://s3.amazonaws.com/bucket</code> in the <code>Sites</code> panel;
 # From the <code>Sites</code> panel, right click on the GET request and select <code>Attack -> Fuzz</code> to configure the fuzzer;
 # Select the word <code>bucket</code> from the request to tell the fuzzer to fuzz in that location;
 # Click <code>Add</code> and <code>Add</code> again to specify the payload the fuzzer will use;


### PR DESCRIPTION
ZAP left OWASP over a year ago, this just adjust naming.